### PR TITLE
Fix param decoding

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -221,7 +221,9 @@ export const ErrNoAccessToken = new Error('no access_token')
  */
 const urlDecode = (urlString: string): Map<string,string> => Map(urlString.split('&').map<[string,string]>(
   (param: string): [string,string] => {
-    const [k, v] = param.split('=').map(decodeURIComponent)
+    const sepIndex = param.indexOf("=")
+    const k = decodeURIComponent(param.slice(0, sepIndex))
+    const v = decodeURIComponent(param.slice(sepIndex + 1))
     return [k, v]
   }))
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -294,17 +294,19 @@ OAuthCallback.propTypes = {
  * @hidden
  */
 class ClosingErrorBoundary extends React.PureComponent {
+  state = { errored: false }
+
   static getDerivedStateFromError(error: string) {
     console.log(error)
     // window.close()
+    return { errored: true }
   }
-
 
   static propTypes = {
     children: PropTypes.func.isRequired
   }
 
-  render() { return this.props.children }
+  render() { return this.state.errored ? null : this.props.children }
 }
 
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -230,8 +230,7 @@ const urlDecode = (urlString: string): Map<string,string> => Map(urlString.split
 /**
  * @hidden
  */
-const OAuthCallbackHandler: React.FunctionComponent<{}> = () => {
-  const [state] = useStorage(oauthStateName)
+const OAuthCallbackHandler: React.FunctionComponent<{}> = ({ children }) => {
   const { target } = JSON.parse(state)
   const [ /* token */, setToken ] = useStorage(
     storagePrefix + '-' + JSON.stringify(target)
@@ -254,7 +253,7 @@ const OAuthCallbackHandler: React.FunctionComponent<{}> = () => {
     window.close()
   }, [])
 
-  return <React.Fragment>'please wait...'</React.Fragment>
+  return <React.Fragment>{children || "please wait..."}</React.Fragment>
 }
 
 /**
@@ -278,11 +277,12 @@ export const OAuthCallback: React.FunctionComponent<{
    * When set to true, errors are thrown
    * instead of just closing the window.
    */
-  errorBoundary = true
+  errorBoundary = true,
+  children
 }) => {
-  if (errorBoundary === false) return <OAuthCallbackHandler />
+  if (errorBoundary === false) return <OAuthCallbackHandler>{children}</OAuthCallbackHandler>
   return <ClosingErrorBoundary>
-    <OAuthCallbackHandler />
+    <OAuthCallbackHandler>{children}</OAuthCallbackHandler>
   </ClosingErrorBoundary>
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,6 +24,25 @@ const storagePrefix = 'react-oauth2-hook'
  */
 const oauthStateName = storagePrefix + '-state-token-challenge'
 
+export interface Options {
+  /**
+   * The OAuth authorize URL to retrieve the token from.
+   */
+  authorizeUrl: string;
+  /**
+   * The OAuth scopes to request.
+   */
+  scope?: string[];
+  /**
+   * The OAuth `redirect_uri` callback.
+   */
+  redirectUri: string;
+  /**
+   * The OAuth `client_id` corresponding to the requesting client.
+   */
+  clientID: string;
+}
+
 /**
  * useOAuth2Token is a React hook providing an OAuth2 implicit grant token.
  *
@@ -111,12 +130,7 @@ export const useOAuth2Token = ({
    * requesting client.
    */
   clientID
-}: {
-  authorizeUrl: string
-  scope: string[],
-  redirectUri: string,
-  clientID: string
-}): [
+}: Options): [
   OAuthToken | undefined,
   getToken,
   setToken
@@ -125,11 +139,11 @@ export const useOAuth2Token = ({
     authorizeUrl, scope, clientID
   }
 
-  const [token, setToken]: [OAuthToken | undefined, (newValue: string) => void] = useStorage(
+  const [token, setToken] = useStorage<string>(
     storagePrefix + '-' + JSON.stringify(target)
   )
 
-  let [state, setState] = useStorage(
+  let [state, setState] = useStorage<string>(
     oauthStateName
   )
 
@@ -231,6 +245,7 @@ const urlDecode = (urlString: string): Map<string,string> => Map(urlString.split
  * @hidden
  */
 const OAuthCallbackHandler: React.FunctionComponent<{}> = ({ children }) => {
+  const [state] = useStorage<string>(oauthStateName)
   const { target } = JSON.parse(state)
   const [ /* token */, setToken ] = useStorage(
     storagePrefix + '-' + JSON.stringify(target)


### PR DESCRIPTION
This fixes a few issues, one major, and a couple other minor ones:
* When decoding params from `window.location.search` or `window.location.hash` you would truncate any values that contained unencoded `=` characters at the first instance of one. (e.g. `/?foo=bar=baz` would ideally decode to `foo` and `bar=baz` when it was previously only `foo` and `bar`)
* The default `please wait....` message can now be replaced by simply passing children to the `OAuthCallback` component (e.g. `<OAuthCallback><LoadingSpinner /></OAuthCallback>`)
* The default error boundary provided would not close the window as advertised, nor would it unmount the underlying callback handler, resulting in the same error being spammed to the browser console as fast as react could re-render the tree. It now will unmount its children after one error is thrown. (I could see an argument for the auto-close behavior being configurable somehow)
